### PR TITLE
Metatable

### DIFF
--- a/TestLauncher.lua
+++ b/TestLauncher.lua
@@ -15,6 +15,7 @@ local tests = {
   "TableModule",
   "Bit32Module",
   "CoroutineModule",
+  "Metatable",
 }
 
 local totalPassed = 0

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -1802,7 +1802,22 @@ function Loader.eval( postfix, scope, line )
           if a.type == "function" or b.type == "function" then
             error("attempt to subtract "..a.type.." from "..b.type.." on line "..token.line)
           end
-          table.insert(stack, val(a.value-b.value))
+
+          local event
+          if a.type == "table" then
+            event = Loader.getMetaEvent( a, "__sub" )
+          end
+          if not event and b.type == "table" then
+            event = Loader.getMetaEvent( b, "__sub" )
+          end
+
+          if event and event.type == "function" then
+            Loader.callFunc( event, Loader._varargs( a, b ), function(result) --varargs result
+              table.insert(stack, result.value)
+            end)
+          else
+            table.insert(stack, val(a.value-b.value))
+          end
 
         elseif token.value == "==" then
           local b, a = pop(stack, scope, line), pop(stack, scope, line)

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -1766,7 +1766,22 @@ function Loader.eval( postfix, scope, line )
           if a.type == "function" or b.type == "function" then
             error("attempt to multiply "..a.type.." with "..b.type.." on line "..token.line)
           end
-          table.insert(stack, val(a.value*b.value))
+
+          local event
+          if a.type == "table" then
+            event = Loader.getMetaEvent( a, "__mul" )
+          end
+          if not event and b.type == "table" then
+            event = Loader.getMetaEvent( b, "__mul" )
+          end
+
+          if event and event.type == "function" then
+            Loader.callFunc( event, Loader._varargs( a, b ), function(result) --varargs result
+              table.insert(stack, result.value)
+            end)
+          else
+            table.insert(stack, val(a.value*b.value))
+          end
 
         elseif token.value == "/" then
           local b, a = pop(stack, scope, line), pop(stack, scope, line)

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -1717,7 +1717,14 @@ function Loader.eval( postfix, scope, line )
           if a.value == "function" then
             error("attempt to get the length of a function on line "..token.line)
           end
-          table.insert(stack, val(#(a.type=="table" and Loader.tableIndexes[a.value] or a.value)))
+          local event = Loader.getMetaEvent(a, "__len")
+          if event.type ~= "nil" then
+            Loader.callFunc( event, Loader._varargs( a ), function( size )
+              table.insert(stack, size.value)
+            end)
+          else
+            table.insert(stack, val(#(a.type=="table" and Loader.tableIndexes[a.value] or a.value)))
+          end
 
         elseif token.value == "^" then
           local b, a = pop(stack, scope, line), pop(stack, scope, line)

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -2033,7 +2033,22 @@ function Loader.eval( postfix, scope, line )
           if a.type == "function" or b.type == "function" then
             error("attempt to concat "..a.type.." with "..b.type.." on line "..token.line)
           end
-          table.insert(stack, val(a.value .. b.value))
+
+          local event
+          if a.type == "table" then
+            event = Loader.getMetaEvent( a, "__concat" )
+          end
+          if not event and b.type == "table" then
+            event = Loader.getMetaEvent( b, "__concat" )
+          end
+
+          if event and event.type == "function" then
+            Loader.callFunc( event, Loader._varargs( a, b ), function(result) --varargs result
+              table.insert(stack, result.value)
+            end)
+          else
+            table.insert(stack, val(a.value .. b.value))
+          end
 
         elseif token.value == "," then
           local b, a = pop(stack, scope, line, true), pop(stack, scope, line, true)

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -400,11 +400,14 @@ function Loader._chunkType( text )
 	-- elseif text:match"//.+" then 
 	-- 	return false
   end
+  
   if text:sub(1,3) == "..." then
     if text == "..." then 
       return "var"
     end
     return false
+  elseif text == "0x" or text == "0b" then
+    return "num" --incomplete
   end
 	for _, name in ipairs{ "op","num","var","str" } do
 		local group = Loader._patterns[ name ]
@@ -529,7 +532,15 @@ function Loader.cleanupTokens( tokens )
       }
 
       if tokenType == "num" then
-        infoToken.value = tonumber(infoToken.value)
+        local base
+        if token:sub(1,2) == "0b" then
+          base = 2
+          infoToken.value = infoToken.value:sub(3)
+        elseif token:sub(1,2) == "0x" then
+          base = 16
+          infoToken.value = infoToken.value:sub(3)
+        end
+        infoToken.value = tonumber(infoToken.value, base)
 
         if prior and prior.value == "-"
         and ((twicePrior and twicePrior.type == "op" and (

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -1468,6 +1468,9 @@ end
 
 --async
 function Loader.assignToTableWithEvents( tableValue, keyValue, valueValue )
+  if not tableValue then error("expected tableValue",2 ) end
+  if not keyValue then error("expected keyValue",2 ) end
+  if not valueValue then error("expected valueValue",2 ) end
   local index = Loader.getTableIndex( tableValue )
   local k = index[ keyValue.value ]
   local v = tableValue.value[ keyValue ] or tableValue.value[ k ]
@@ -1493,6 +1496,13 @@ function Loader.getMetaEvent( tableValue, eventName )
   local index = Loader.getTableIndex( meta )
   local k = index[ eventName ]
   return meta.value[ k ] or NIL
+end
+
+function Loader.indexTable( tableValue, keyValue )
+  local index = Loader.getTableIndex( tableValue )
+  local k = index[ keyValue.value ]
+  local v = tableValue.value[ keyValue ] or tableValue.value[ k ]
+  return v or Loader.constants["nil"]
 end
 
 --async
@@ -2026,6 +2036,8 @@ function Scope:addGlobals()
 
   self:setNativeFunc( "getmetatable", Loader.getmetatable, false, false )
   self:setNativeFunc( "setmetatable", Loader.setmetatable, false, false )
+  self:setNativeFunc( "rawset", Loader.assignToTable, false, false )
+  self:setNativeFunc( "rawget", Loader.indexTable, false, false )
 
   ---------------------------------------------------------
   -- math
@@ -2442,8 +2454,9 @@ function Loader.execute( instructions, env, ... )
                   top:set(inst.isLocal, target.name, stack[i] or Loader.constants["nil"] )
                 else
                   local nameVal = Loader._val(target.name)
-                  target.place.value[nameVal] = stack[i]
-                  Loader.tableIndexes[target.place.value][target.name] = nameVal
+                  Loader.assignToTableWithEvents( target.place, nameVal, stack[i] )
+                  -- target.place.value[nameVal] = stack[i]
+                  -- Loader.tableIndexes[target.place.value][target.name] = nameVal
                 end
               end
               return true

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -1390,7 +1390,7 @@ end
 --TODO varargs issue
 function Loader._popVal( stack, scope, line, keepVarargs )
   local token = table.remove(stack)
-  if not token then error("Error, empty stack from expression on line "..line) end
+  if not token then error("Error, empty stack from expression on line "..line, 2) end
   local value = Loader._tokenValue( token, scope )
   if value.type == "varargs" and not keepVarargs then
     return value.value
@@ -1909,8 +1909,8 @@ function Loader.eval( postfix, scope, line )
 
           local eventA = Loader.getMetaEvent( a, "__eq" )
           local eventB = Loader.getMetaEvent( b, "__eq" )
-          if eventA and eventA.type == "funciton" and eventA == eventB then
-            Loader.callFunc( event, Loader._varargs( a, b ), function(result) --varargs result
+          if eventA and eventA.type == "function" and eventA == eventB then
+            Loader.callFunc( eventA, Loader._varargs( a, b ), function(result) --varargs result
               table.insert(stack, result.value)
             end)
           else
@@ -1929,9 +1929,9 @@ function Loader.eval( postfix, scope, line )
 
           local eventA = Loader.getMetaEvent( a, "__eq" )
           local eventB = Loader.getMetaEvent( b, "__eq" )
-          if eventA and eventA.type == "funciton" and eventA == eventB then
-            Loader.callFunc( event, Loader._varargs( a, b ), function(result) --varargs result
-              table.insert(stack, not result.value)
+          if eventA and eventA.type == "function" and eventA == eventB then
+            Loader.callFunc( eventA, Loader._varargs( a, b ), function(result) --varargs result
+              table.insert(stack, Loader._val(not result.value))
             end)
           else
             table.insert(stack, val(a.value ~= b.value))

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -1492,7 +1492,7 @@ function Loader.getMetaEvent( tableValue, eventName )
   if meta.type=="nil" then return NIL end
   local index = Loader.getTableIndex( meta )
   local k = index[ eventName ]
-  return meta[ k ] or NIL
+  return meta.value[ k ] or NIL
 end
 
 --async
@@ -1516,7 +1516,7 @@ function Loader.indexTableWithEvents( tableValue, keyValue, callback, loop )
   if __index.type == "function" then
     Loader.callFunc( __index, Loader._varargs( tableValue, keyValue ), function( values )
       --only first value is returned
-      callback( values[1] )
+      callback( values.varargs[1] )
     end )
   elseif __index.type == "table" then
     Async.insertTasks({
@@ -2023,6 +2023,9 @@ function Scope:addGlobals()
   end, false )
 
   self:setNativeFunc( "type", function( value ) return value.type end, false, nil)
+
+  self:setNativeFunc( "getmetatable", Loader.getmetatable, false, false )
+  self:setNativeFunc( "setmetatable", Loader.setmetatable, false, false )
 
   ---------------------------------------------------------
   -- math

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -8,9 +8,10 @@ local Net = {}
 Loader.tableIndexes = {}
 Loader.strings = {}
 Loader.metatables = {
-  string = {}
+  string = {value={}, type="table"}
 }
 
+Loader.tableIndexes[ Loader.metatables.string.value ] = {}
 
 --[table][raw key] -> wrapped key
 setmetatable(Loader.tableIndexes, {
@@ -1524,7 +1525,7 @@ function Loader.getMetaEvent( tableValue, eventName )
   if not meta or meta.type == "nil" then
     return NIL
   end
-  if meta.type=="nil" then return NIL end
+  
   local index = Loader.getTableIndex( meta )
   local k = index[ eventName ]
   return meta.value[ k ] or NIL
@@ -1944,8 +1945,8 @@ function Loader.eval( postfix, scope, line )
 
           local eventA = Loader.getMetaEvent( a, "__le" )
           local eventB = Loader.getMetaEvent( b, "__le" )
-          if eventA and eventA.type == "funciton" and eventA == eventB then
-            Loader.callFunc( event, Loader._varargs( a, b ), function(result) --varargs result
+          if (eventA and eventA.type == "function") or (eventB and eventB.type == "function") then
+            Loader.callFunc( eventA.type=="function" and eventA or eventB, Loader._varargs( a, b ), function(result) --varargs result
               table.insert(stack, result.value)
             end)
           else
@@ -1961,8 +1962,8 @@ function Loader.eval( postfix, scope, line )
 
           local eventA = Loader.getMetaEvent( a, "__le" )
           local eventB = Loader.getMetaEvent( b, "__le" )
-          if eventA and eventA.type == "funciton" and eventA == eventB then
-            Loader.callFunc( event, Loader._varargs( b, a ), function(result) --varargs result, args swapped
+          if (eventA and eventA.type == "function") or (eventB and eventB.type == "function") then
+            Loader.callFunc( eventA.type=="function" and eventA or eventB, Loader._varargs( b, a ), function(result) --varargs result, args swapped
               table.insert(stack, result.value)
             end)
           else
@@ -1978,8 +1979,8 @@ function Loader.eval( postfix, scope, line )
 
           local eventA = Loader.getMetaEvent( a, "__lt" )
           local eventB = Loader.getMetaEvent( b, "__lt" )
-          if eventA and eventA.type == "funciton" and eventA == eventB then
-            Loader.callFunc( event, Loader._varargs( a, b ), function(result) --varargs result
+          if (eventA and eventA.type == "function") or (eventB and eventB.type == "function") then
+            Loader.callFunc( eventA.type=="function" and eventA or eventB, Loader._varargs( a, b ), function(result) --varargs result
               table.insert(stack, result.value)
             end)
           else
@@ -1994,8 +1995,8 @@ function Loader.eval( postfix, scope, line )
 
           local eventA = Loader.getMetaEvent( a, "__lt" )
           local eventB = Loader.getMetaEvent( b, "__lt" )
-          if eventA and eventA.type == "funciton" and eventA == eventB then
-            Loader.callFunc( event, Loader._varargs( b, a ), function(result) --varargs result, args swapped
+          if (eventA and eventA.type == "function") or (eventB and eventB.type == "function") then
+            Loader.callFunc( eventA.type=="function" and eventA or eventB, Loader._varargs( b, a ), function(result) --varargs result, args swapped
               table.insert(stack, result.value)
             end)
           else
@@ -2085,7 +2086,7 @@ function Loader.eval( postfix, scope, line )
           else
             table.insert(stack, val(a.value % b.value))
           end
-          
+
         elseif token.value == "-unm" then --token cleanup does some of this already
           local a = pop(stack, scope, line)
           if a.type == "function" then

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -1644,6 +1644,12 @@ function Loader.eval( postfix, scope, line )
           if func.type == "table" then
             local __call = Loader.getMetaEvent( func, "__call" )
             if __call and __call.type=="function" then
+              if args.type ~= varargs then
+                args = Loader._varargs( func, args )
+              else
+                table.insert( args.varargs, func )
+              end
+              args.value = func
               func = __call
             end
           end
@@ -2455,8 +2461,6 @@ function Loader.execute( instructions, env, ... )
                 else
                   local nameVal = Loader._val(target.name)
                   Loader.assignToTableWithEvents( target.place, nameVal, stack[i] )
-                  -- target.place.value[nameVal] = stack[i]
-                  -- Loader.tableIndexes[target.place.value][target.name] = nameVal
                 end
               end
               return true

--- a/tests/loadTests/LoadTest.lua
+++ b/tests/loadTests/LoadTest.lua
@@ -6,7 +6,7 @@ local testUtils = require"libs/testUtils"
 local matchers = require"MockProxy".static
 local eq = matchers.eq
 local any = matchers.any
-
+local testUtils = require"libs/testUtils"
 
 local tester = Tester:new()
 
@@ -34,6 +34,96 @@ do
   end)
   --expect
   printProxy{ "Hello world!" }.exact()
+end
+
+-------------
+-- , order --
+-------------
+do
+  --given
+  local src = [=[
+    return 1,2,3,4,5,6,7
+  ]=]
+  local env = Env:new()
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local test = testUtils.codeTest( tester, ", order", env, libs, src )
+  
+  for i=1,7 do
+    test:var_eq(i, i)
+  end
+end
+
+-------------
+-- (), order --
+-------------
+do
+  --given
+  local src = [=[
+    function t()
+      return 1,2,3,4
+    end
+    return t(),5,6,7
+  ]=]
+  local env = Env:new()
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local test = testUtils.codeTest( tester, "(), order", env, libs, src )
+  
+  test:var_eq(1, 1)
+  test:var_eq(2, 5)
+  test:var_eq(3, 6)
+  test:var_eq(4, 7)
+end
+
+-------------
+-- ,() order --
+-------------
+do
+  --given
+  local src = [=[
+    function t()
+      return 1,2,3,4
+    end
+    return 5,6,7,t()
+  ]=]
+  local env = Env:new()
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local test = testUtils.codeTest( tester, ",() order", env, libs, src )
+  
+  test:var_eq(1, 5)
+  test:var_eq(2, 6)
+  test:var_eq(3, 7)
+  test:var_eq(4, 1)
+  test:var_eq(5, 2)
+  test:var_eq(6, 3)
+  test:var_eq(7, 4)
+end
+
+-------------
+-- ,(), order --
+-------------
+do
+  --given
+  local src = [=[
+    function t()
+      return 1,2,3,4
+    end
+    return 5,t(),7
+  ]=]
+  local env = Env:new()
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local test = testUtils.codeTest( tester, ",(), order", env, libs, src )
+  
+  test:var_eq(1, 5)
+  test:var_eq(2, 1)
+  test:var_eq(3, 7)
 end
 
 return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -374,4 +374,44 @@ do
   test:var_eq(1, "ok")
 end
 
+-----------
+-- __add --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x =  5 }
+    local u = { x = 10 }
+    local m = {
+      __add = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a + b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      1 + t, 
+      t + 1,
+      t + u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__add", env, libs, src)
+
+  test:var_eq(1, 6)
+  test:var_eq(2, 6)
+  test:var_eq(3, 15)
+end
+
 return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -35,5 +35,29 @@ do
   test:var_eq(1, "ok")
 end
 
+-------------------
+-- __index function --
+-------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    setmetatable( t, {
+      __index = function(t, k)
+        return k + 1
+      end
+    })
+    return t[122]
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__index function", env, libs, src)
+
+  test:var_eq(1, 123, "Expected index function to return k + 1 (123), got $1")
+end
+
 
 return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -109,5 +109,31 @@ do
   test:var_eq(1, "ok")
 end
 
+----------------
+-- __call --
+----------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+
+    setmetatable( t, {
+      __call = function( t, arg )
+        return arg + 1
+      end
+    })
+
+    return t( 10 )
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__call", env, libs, src)
+
+  test:var_eq(1, 11)
+end
+
 
 return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -348,4 +348,30 @@ do
   test:var_eq(1, 5)
 end
 
+-----------
+-- __unm --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    
+    setmetatable( t, {
+      __unm = function()
+        return "ok"
+      end
+    })
+
+    return -t
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__unm", env, libs, src)
+
+  test:var_eq(1, "ok")
+end
+
 return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -1,0 +1,39 @@
+local Tester = require"TestRunner"
+local Env = require"MockEnv"
+local testUtils = require"libs/testUtils"
+
+local matchers = require"MockProxy".static
+local eq = matchers.eq
+local any = matchers.any
+
+local tester = Tester:new()
+
+-----------------------------------------------------------------
+-- Tests
+-----------------------------------------------------------------
+
+-------------------
+-- __index table --
+-------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    local u = { x = "ok" }
+    setmetatable( t, {
+      __index = u
+    })
+    return t.x
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__index table", env, libs, src)
+
+  test:var_eq(1, "ok")
+end
+
+
+return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -35,9 +35,9 @@ do
   test:var_eq(1, "ok")
 end
 
--------------------
+----------------------
 -- __index function --
--------------------
+----------------------
 do
   local env = Env:new()
   local common = testUtils.common(env)
@@ -57,6 +57,56 @@ do
   local test = testUtils.codeTest(tester, "__index function", env, libs, src)
 
   test:var_eq(1, 123, "Expected index function to return k + 1 (123), got $1")
+end
+
+----------------------
+-- __index defaults --
+----------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = "ok" }
+    local u = { x = "not ok" }
+    setmetatable( t, {
+      __index = u
+    })
+    return t.x
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__index defaults", env, libs, src)
+
+  test:var_eq(1, "ok")
+end
+
+----------------
+-- __newindex --
+----------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+
+    setmetatable( t, {
+      __newindex = function( t, k, v )
+        rawset( t, "x", "ok" )
+      end
+    })
+
+    t.foo = 10
+    return t.x
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__newindex", env, libs, src)
+
+  test:var_eq(1, "ok")
 end
 
 

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -10,6 +10,7 @@ local tester = Tester:new()
 
 -----------------------------------------------------------------
 -- Tests
+-- http://lua-users.org/wiki/MetatableEvents
 -----------------------------------------------------------------
 
 -------------------
@@ -283,6 +284,68 @@ do
   local test = testUtils.codeTest(tester, "__len", env, libs, src)
 
   test:var_eq(1, 123)
+end
+
+-------------
+-- __pairs --
+-------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    
+    setmetatable( t, {
+      __pairs = function()
+        return "hello":gmatch"."
+      end
+    })
+    
+    local hits = 0
+    for x in pairs( t ) do
+      hits = hits + 1
+    end
+
+    return hits
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__pairs", env, libs, src)
+
+  test:var_eq(1, 5)
+end
+
+-------------
+-- __ipairs --
+-------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    
+    setmetatable( t, {
+      __ipairs = function()
+        return "hello":gmatch"."
+      end
+    })
+    
+    local hits = 0
+    for x in ipairs( t ) do
+      hits = hits + 1
+    end
+
+    return hits
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__ipairs", env, libs, src)
+
+  test:var_eq(1, 5)
 end
 
 return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -734,7 +734,7 @@ do
 
   test:var_eq(1, 16)
   test:var_eq(2, 16)
-  test:var_eq(3,  2)
+  test:var_eq(3,  1)
 end
 
 -----------

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -777,6 +777,33 @@ do
   test:var_eq(3, 19)
 end
 
+-----------
+-- __bnot --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 17 }
+    local m = {
+      __bnot = function(a)
+        return ~a.x
+      end
+    }
+    
+    setmetatable( t, m )
+
+    return ~t
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__bnot", env, libs, src)
+
+  test:var_eq(1, bit32.bnot(17))
+end
+
 ------------
 -- __bxor --
 ------------

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -790,7 +790,7 @@ do
     local t = { x = 17 }
     local u = { x = 3 }
     local m = {
-      __bor = function(a, b)
+      __bxor = function(a, b)
         if type(a) == "table" then
           a = a.x
         end
@@ -810,7 +810,7 @@ do
          t ~ u
   ]=]
 
-  local test = testUtils.codeTest(tester, "__bor", env, libs, src)
+  local test = testUtils.codeTest(tester, "__bxor", env, libs, src)
 
   test:var_eq(1, 43)
   test:var_eq(2, 43)
@@ -965,7 +965,7 @@ do
         t == u
   ]=]
 
-  local test = testUtils.codeTest(tester, "__concat", env, libs, src)
+  local test = testUtils.codeTest(tester, "__eq", env, libs, src)
 
   test:var_isFalse(1)
   test:var_isFalse(2)
@@ -986,7 +986,13 @@ do
     local u = { x = 3 }
     local m = {
       __lt = function(a, b)
-        return a.x < b.x
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a < b
       end
     }
     
@@ -1021,8 +1027,14 @@ do
     local t = { x = 2 }
     local u = { x = 3 }
     local m = {
-      __lt = function(a, b)
-        return a.x <= b.x
+      __le = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a <= b
       end
     }
     

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -347,7 +347,8 @@ do
 
   test:var_eq(1, 5)
 end
-
+----------------------------------------------------------------------------------------------------------------------------------------
+-- arithmetic
 -----------
 -- __unm --
 -----------
@@ -412,6 +413,637 @@ do
   test:var_eq(1, 6)
   test:var_eq(2, 6)
   test:var_eq(3, 15)
+end
+
+-----------
+-- __sub --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x =  5 }
+    local u = { x = 10 }
+    local m = {
+      __sub = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a - b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      1 - t, 
+      t - 1,
+      t - u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__sub", env, libs, src)
+
+  test:var_eq(1, -4)
+  test:var_eq(2,  4)
+  test:var_eq(3, -5)
+end
+
+-----------
+-- __mul --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x =  5 }
+    local u = { x = 10 }
+    local m = {
+      __mul = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a * b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      2 * t, 
+      t * 2,
+      t * u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__mul", env, libs, src)
+
+  test:var_eq(1, 10)
+  test:var_eq(2, 10)
+  test:var_eq(3, 50)
+end
+
+-----------
+-- __div --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 8 }
+    local u = { x = 4 }
+    local m = {
+      __div = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a / b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      64 / t, 
+       t / 2,
+       t / u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__div", env, libs, src)
+
+  test:var_eq(1, 8)
+  test:var_eq(2, 4)
+  test:var_eq(3, 2)
+end
+
+-----------
+-- __idiv --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 17 }
+    local u = { x = 3 }
+    local m = {
+      __idiv = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a // b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      100 // t, 
+        t // 2,
+        t // u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__idiv", env, libs, src)
+
+  test:var_eq(1, 5)
+  test:var_eq(2, 8)
+  test:var_eq(3, 5)
+end
+
+-----------
+-- __mod --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 17 }
+    local u = { x = 3 }
+    local m = {
+      __mod = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a % b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      100 % t, 
+        t % 2,
+        t % u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__mod", env, libs, src)
+
+  test:var_eq(1, 15)
+  test:var_eq(2,  1)
+  test:var_eq(3,  2)
+end
+
+-----------
+-- __pow --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 5 }
+    local u = { x = 3 }
+    local m = {
+      __pow = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a ^ b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      2 ^ t, 
+      t ^ 2,
+      t ^ u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__pow", env, libs, src)
+
+  test:var_eq(1,  32)
+  test:var_eq(2,  25)
+  test:var_eq(3, 125)
+end
+
+--------------
+-- __concat --
+--------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = "world" }
+    local u = { x = "!" }
+    local m = {
+      __concat = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a .. b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      "hello " .. t, 
+        t .. "!",
+        t .. u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__concat", env, libs, src)
+
+  test:var_eq(1, "hello world")
+  test:var_eq(2, "world!")
+  test:var_eq(3, "world!")
+end
+
+--------------------------------------------------------------------------------------------------------------------------
+-- Bitwise
+-----------
+-- __band --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 17 }
+    local u = { x = 3 }
+    local m = {
+      __band = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a & b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      0x3A & t, 
+         t & 0x3A,
+         t & u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__band", env, libs, src)
+
+  test:var_eq(1, 16)
+  test:var_eq(2, 16)
+  test:var_eq(3,  2)
+end
+
+-----------
+-- __bor --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 17 }
+    local u = { x = 3 }
+    local m = {
+      __bor = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a | b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      0x3A | t, 
+         t | 0x3A,
+         t | u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__bor", env, libs, src)
+
+  test:var_eq(1, 59)
+  test:var_eq(2, 59)
+  test:var_eq(3, 19)
+end
+
+------------
+-- __bxor --
+------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 17 }
+    local u = { x = 3 }
+    local m = {
+      __bor = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a ~ b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      0x3A ~ t, 
+         t ~ 0x3A,
+         t ~ u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__bor", env, libs, src)
+
+  test:var_eq(1, 43)
+  test:var_eq(2, 43)
+  test:var_eq(3, 18)
+end
+
+------------
+-- __shl --
+------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 17 }
+    local u = { x = 3 }
+    local m = {
+      __shl = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a << b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      3 << t, 
+      t << 3,
+      t << u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__shl", env, libs, src)
+
+  test:var_eq(1, 393216)
+  test:var_eq(2,    136)
+  test:var_eq(3,    136)
+end
+
+------------
+-- __shr -- (arithmetic)
+------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 5 }
+    local u = { x = 2 }
+    local m = {
+      __shr = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a >> b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      0xF17C >> t, 
+      t >> 1,
+      t >> u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__shr", env, libs, src)
+
+  test:var_eq(1, 1931)
+  test:var_eq(2,    2)
+  test:var_eq(3,    1)
+end
+
+------------
+-- __ashr -- (logical)
+------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 5 }
+    local u = { x = 2 }
+    local m = {
+      __ashr = function(a, b)
+        if type(a) == "table" then
+          a = a.x
+        end
+        if type(b) == "table" then
+          b = b.x
+        end
+        return a >>> b
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      0xF17C >>> t, 
+      t >>> 1,
+      t >>> u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__ashr", env, libs, src)
+
+  test:var_eq(1, 1931)
+  test:var_eq(2,    2)
+  test:var_eq(3,    1)
+end
+-----------------------------------------------------------------------------------------------------------------------------------------
+-- Equivalence / Comparison
+----------
+-- __eq --
+----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = "world" }
+    local u = { x = "!" }
+    local m = {
+      __eq = function(a, b)
+        return a.x == b.x
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      "hello " == t, 
+        t == "!",
+        t == u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__concat", env, libs, src)
+
+  test:var_isFalse(1)
+  test:var_isFalse(2)
+  test:var_isTrue(3)
+end
+
+----------
+-- __lt --
+----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 2 }
+    local u = { x = 3 }
+    local m = {
+      __lt = function(a, b)
+        return a.x < b.x
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      1 < t, 
+      t < 5,
+      t < u,
+      2 < t
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__lt", env, libs, src)
+
+  test:var_isTrue(1)
+  test:var_isTrue(2)
+  test:var_isTrue(3)
+  test:var_isFalse(4)
+end
+
+----------
+-- __le --
+----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = { x = 2 }
+    local u = { x = 3 }
+    local m = {
+      __lt = function(a, b)
+        return a.x <= b.x
+      end
+    }
+    
+    setmetatable( t, m )
+    setmetatable( u, m )
+
+    return 
+      1 <= t, 
+      t <= 5,
+      t <= u,
+      2 <= t,
+      99 <= t
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__le", env, libs, src)
+
+  test:var_isTrue(1)
+  test:var_isTrue(2)
+  test:var_isTrue(3)
+  test:var_isTrue(4)
+  test:var_isFalse(5)
 end
 
 return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -260,4 +260,29 @@ do
   test:var_eq(1, "ok")
 end
 
+-----------
+-- __len --
+-----------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    
+    setmetatable( t, {
+      __len = function()
+        return 123
+      end
+    })
+    return #t
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__len", env, libs, src)
+
+  test:var_eq(1, 123)
+end
+
 return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -135,5 +135,129 @@ do
   test:var_eq(1, 11)
 end
 
+----------------
+-- getmetatable --
+----------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    local u = {}
+    setmetatable( t, u )
+    
+    return getmetatable( t ) == u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "getmetatable", env, libs, src)
+
+  test:var_isTrue(1)
+end
+
+-----------------
+-- __metatable --
+-----------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    local u = {}
+    setmetatable( t, {
+      __metatable = u
+    })
+
+    return getmetatable( t ) == u
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__metatable", env, libs, src)
+
+  test:var_isTrue(1)
+end
+
+------------------------------
+-- __metatable is protected --
+------------------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    local u = {}
+
+    setmetatable( t, {
+      __metatable = u
+    })
+
+    setmetatable( t, {
+      __metatable = u
+    })
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__metatable is protected", env, libs, src)
+
+  test:expectError("cannot change a protected metatable")
+end
+
+-----------------------
+-- __tostring string --
+-----------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {}
+    
+    setmetatable( t, {
+      __tostring = "ok"
+    })
+
+    return tostring( t )
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__tostring string", env, libs, src)
+
+  test:var_eq(1, "ok")
+end
+
+---------------------
+-- __tostring func --
+---------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local t = {
+      z = "ok"
+    }
+    
+    setmetatable( t, {
+      __tostring = function( x )
+        return x.z
+      end
+    })
+
+    return tostring( t )
+  ]=]
+
+  local test = testUtils.codeTest(tester, "__tostring func", env, libs, src)
+
+  test:var_eq(1, "ok")
+end
 
 return tester

--- a/tests/loadTests/Metatable.lua
+++ b/tests/loadTests/Metatable.lua
@@ -949,8 +949,14 @@ do
 
   local src = [=[
     local t = { x = "world" }
-    local u = { x = "!" }
+    local u = { x = "world" }
+    local v = { x = "world" }
     local m = {
+      __eq = function(a, b)
+        return a.x == b.x
+      end
+    }
+    local m2 = {
       __eq = function(a, b)
         return a.x == b.x
       end
@@ -958,18 +964,23 @@ do
     
     setmetatable( t, m )
     setmetatable( u, m )
+    setmetatable( v, m2 )
 
     return 
       "hello " == t, 
         t == "!",
-        t == u
+        t == u,
+        not (t ~= u),
+        t == v
   ]=]
 
   local test = testUtils.codeTest(tester, "__eq", env, libs, src)
 
-  test:var_isFalse(1)
-  test:var_isFalse(2)
-  test:var_isTrue(3)
+  test:var_isFalse(1, "Expected false for arg #1, got $1")
+  test:var_isFalse(2, "Expected false for arg #2, got $1")
+  test:var_isTrue( 3, "Expected true for arg #3, got $1")
+  test:var_isTrue( 4, "Expected true for arg #4, got $1")
+  test:var_isFalse( 5, "Expected false for arg #5, got $1")
 end
 
 ----------


### PR DESCRIPTION
Also includes `hex` literals, `bin` literals,  `floor div` (`//` op)
All bitwise meta events

Skips `__mode`

Includes fix for vararg joining (`,` op)

closes #17 
closes #24 