### PR TITLE
Random fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ https://github.com/users/TheIncgi/projects/2/views/1
  - Auto pauses each tick, adjustable # of ops per tick (based on internal loops mostly) 
  - When doing formatting like `("%2d:%d"):format(hour, min)` the first `()` can be skipped like this:
    `"%2d:%d":format(hour, min)`
+ - Support for `[[foo]]`/`[=[foo]=]` style strings
+ - stack trace
+ - `continue` in loops
 
 ### Planned features
  - Support for `+=` `-=` `/=` `*=` `~=`, `<<=`, `|=`, `&=`, `>>=`, `>>>=`
- - Support for `[=[foo]=]` style strings (might have already done this one..)
  - Custom searchers/loaders
- - debug library
- - stack trace
+ - debug library (partially implemented)
 
 ## Usage
 [This is the file](https://github.com/TheIncgi/Plasma-projects/blob/main/libs/Load.lua)\

--- a/TestLauncher.lua
+++ b/TestLauncher.lua
@@ -22,6 +22,7 @@ local tests = {
   "ErrorHandlingTests",
   "DebugTests",
   "LoopTests",
+  "ScopeTests",
 }
 
 local totalPassed = 0

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -390,6 +390,7 @@ local RETURN = Async.RETURN
 Loader.keywords = {
   -- ["and"]      = true,
   ["break"]    = true,
+  ["continue"] = true,
   ["do"]       = true,
   ["false"]    = true,
   ["for"]      = true,
@@ -1261,6 +1262,18 @@ function Loader.buildInstructions( tokens, start, exitBlockLevel )
         
 
         --instructions with expresssions
+        elseif token.value == "break" then
+          table.insert(instructions, {
+            op = "break",
+            line = token.line,
+            index = #instructions+1
+          })
+        elseif token.value == "continue" then
+          table.insert(instructions, {
+            op = "continue",
+            line = token.line,
+            index = #instructions+1
+          })
         elseif token.value == "do" then
           table.insert(instructions, {
             op = "createScope",
@@ -4101,6 +4114,25 @@ function Loader.execute( instructions, env, nNamedArgs, ... )
           return --continue
         end
       elseif inst.op == "break" then
+        local t = top
+        while not t.isLoop and t.parent do
+          t = t.parent
+        end
+        if not t.isLoop then
+          error("break statment is not in a loop")
+        end
+        index = t.stop.index + 1
+        return --continue
+      elseif inst.op == "continue" then
+        local t = top
+        while not t.isLoop and t.parent do
+          t = t.parent
+        end
+        if not t.isLoop then
+          error("break statment is not in a loop")
+        end
+        index = t.stop.index --to end/until, loop check there
+        return --continue
       elseif inst.op == "while" then
         top.isLoop = true
         top.start = inst

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -4326,7 +4326,6 @@ function Loader.installExtraFunctions()
         if #out > 1 then table.insert( out, ', ' ) end
         table.insert( out, table.serialize(v, sortFunc, visited) )
       end
-      print(keys)
       for i,k in ipairs( keys ) do
         if type(k)~="number" then
           local v = tbl[k]

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -4394,6 +4394,7 @@ function setup()
   Plasma.scope = Scope:new("PLASMA",1,nil,1)
   Plasma.scope:addGlobals()
   Plasma.scope:addPlasmaGlobals()
+  Loader.installExtraFunctions()
 end
 
 function loop()
@@ -4487,12 +4488,14 @@ local function test()
   print"done"
 end
 
-Loader.installExtraFunctions()
+
 
 -- test()
 return {
   Loader = Loader,
   Async = Async,
   Scope = Scope,
-  Net = Net
+  Net = Net,
+  Plasma = Plasma,
+  setup = setup,
 }

--- a/libs/testUtils.lua
+++ b/libs/testUtils.lua
@@ -9,6 +9,11 @@ end
 
 -- execute source code
 function testUtils.run( src, scope, Loader, Async )
+  if Async.threads
+    and Async.threads[Async.activeThread]  then
+      local t = Async.threads[Async.activeThread]
+      Async.sync( t[#t] )
+  end
   local rawTokens = Async.sync( Loader.tokenize(src) )
   local tokens = Async.sync( Loader.cleanupTokens( rawTokens ) )
   local instructions = Async.sync( Loader.buildInstructions(tokens)  )
@@ -17,16 +22,20 @@ function testUtils.run( src, scope, Loader, Async )
 end
 
 function testUtils.newScope(Scope, testName)
-  testName = testName or "?"
-  local scope =  Scope:new("UNIT_TEST-"..testName, 1, nil, 1)
-  scope:addGlobals()
-  scope:addPlasmaGlobals()
-  return scope
+  error"DEPRECATED"
+  -- testName = testName or "?"
+  -- local scope =  Scope:new("UNIT_TEST-"..testName, 1, nil, 1)
+  -- scope:addGlobals()
+  -- scope:addPlasmaGlobals()
+  -- return scope
 end
 
 function testUtils.codeTest(tester, name, env, libs, src, expectedResultCount)
   return tester:add(name, env, function()
-    local scope = testUtils.newScope(libs.Scope, name)
+    --local scope = testUtils.newScope(libs.Scope, name)
+    libs.setup()
+    local scope = libs.Plasma.scope
+    scope.name = "UNIT_TEST-"..name
     local results = testUtils.run(src, scope, libs.Loader, libs.Async)
     results = results and results.varargs or {}
     if expectedResultCount and #results ~= expectedResultCount then

--- a/tests/loadTests/BasicTable.lua
+++ b/tests/loadTests/BasicTable.lua
@@ -26,12 +26,7 @@ do
     return t[1]
   ]=]
 
-  local test = tester:add("basic index by []", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "basic index by []", env, libs, src)
 
   test:var_eq(1, "ok")
 end
@@ -58,16 +53,7 @@ do
         t[1], t["foo bar"], t["cow"], t["hello"]
   ]=]
 
-  local test = tester:add("multiple index by []", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results then error"Expected return value" end
-    return 
-        results[1].value,
-        results[2].value,
-        results[3].value,
-        results[4].value
-  end)
+  local test = testUtils.codeTest(tester, "multiple index by []", env, libs, src)
 
   test:var_eq(1, 1000, "value 1 expected 1000, got $1")
   test:var_eq(2, 15, "value 2 expected 15, got $1")

--- a/tests/loadTests/BasicTests.lua
+++ b/tests/loadTests/BasicTests.lua
@@ -28,11 +28,10 @@ do
   local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
 
   local printProxy = env:proxy("print", function() end)
+
   --test code
-  tester:add("executes hello world", env, function()
-    local scope = testUtils.newScope(Scope)
-    testUtils.run( src, scope, Loader, Async )
-  end)
+  local test = testUtils.codeTest(tester, "print hello world", env, libs, src)
+  
   --expect
   printProxy{ "Hello world!" }.exact()
 end

--- a/tests/loadTests/ErrorHandlingTests.lua
+++ b/tests/loadTests/ErrorHandlingTests.lua
@@ -147,7 +147,7 @@ do
 
   local src = [=[
     local function unsafe( y )
-      return x + 2
+      return x + 2 --x not y
     end
 
     local function handler(msg, env)

--- a/tests/loadTests/FunctionTests.lua
+++ b/tests/loadTests/FunctionTests.lua
@@ -26,6 +26,7 @@ do
     end
     test()
     OUT_FUNC = not not x
+    return IN_FUNC, OUT_FUNC
   ]=]
   local env = Env:new()
   local common = testUtils.common(env)
@@ -33,16 +34,11 @@ do
   local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
 
   --test code
-  local test = tester:add("scope test", env, function()
-    local scope = testUtils.newScope(Scope)
-    testUtils.run( src, scope, Loader, Async )
-    return scope:getRaw"IN_FUNC".value, scope:getRaw"OUT_FUNC".value
-  end)
+  local test = testUtils.codeTest(tester, "scope test", env, libs, src)
 
   --expect
   test:var_isTrue(1, "expected global `IN_FUNC` to be `true`, actual: $1") --1, first return value
   test:var_isFalse(2, "expected global `OUT_FUNC` to be `false`, actual: $1") --2, second return value
-  V1,V2,V3,V4,V5,V6,V7,V8 = nil, nil, nil, nil, nil, nil, nil, nil
 end
 
 -----------------
@@ -66,10 +62,7 @@ do
   testUtils.setupRequire( Async, Net, common, {path} )
     
   --test code
-  local test = tester:add("requires code", env, function()
-    local scope = testUtils.newScope(Scope)
-    testUtils.run( src, scope, Loader, Async )
-  end)
+  local test = testUtils.codeTest(tester, "require", env, libs, src)
     
 end
 
@@ -94,10 +87,7 @@ do
   common.printProxy{ "ok" }.exact()
     
   --test code
-  local test = tester:add("table function", env, function()
-    local scope = testUtils.newScope(Scope)
-    testUtils.run( src, scope, Loader, Async )
-  end)
+  local test = testUtils.codeTest(tester, "table function", env, libs, src)
     
 end
 

--- a/tests/loadTests/LoopTests.lua
+++ b/tests/loadTests/LoopTests.lua
@@ -95,9 +95,9 @@ do
   test:var_eq(1, 1)
 end
 
----------------
--- for break --
----------------
+------------------
+-- for continue --
+------------------
 do
   --given
   local src = [=[
@@ -114,7 +114,7 @@ do
   local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
 
   --test code
-  local test = testUtils.codeTest(tester, "for break", env, libs, src)
+  local test = testUtils.codeTest(tester, "for continue", env, libs, src)
 
   --expect
   test:var_eq(1, 6)

--- a/tests/loadTests/LoopTests.lua
+++ b/tests/loadTests/LoopTests.lua
@@ -70,5 +70,55 @@ do
   test:var_eq(1, 3)
 end
 
+---------------
+-- for break --
+---------------
+do
+  --given
+  local src = [=[
+    i = 0
+    for j=1,10 do
+      i = i + 1
+      break
+    end
+    return i
+  ]=]
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  --test code
+  local test = testUtils.codeTest(tester, "for break", env, libs, src)
+
+  --expect
+  test:var_eq(1, 1)
+end
+
+---------------
+-- for break --
+---------------
+do
+  --given
+  local src = [=[
+    i = 0
+    for j=1,10 do
+      if j < 5 then continue end
+      i = i + 1
+    end
+    return i
+  ]=]
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  --test code
+  local test = testUtils.codeTest(tester, "for break", env, libs, src)
+
+  --expect
+  test:var_eq(1, 6)
+end
+
 
 return tester

--- a/tests/loadTests/LoopTests.lua
+++ b/tests/loadTests/LoopTests.lua
@@ -38,8 +38,32 @@ do
   for i = 1, 3 do
     printProxy{tostring(i)}:exact()
   end
-  
-  
+end
+
+----------------
+-- for ipairs --
+----------------
+do
+  --given
+  local src = [=[
+    t = {11,12,13,e="nope",f="don't"}
+    for a,b in ipairs( t ) do
+      print(a,b)
+    end
+  ]=]
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  --test code
+  local test = testUtils.codeTest(tester, "for ipairs", env, libs, src)
+
+  --expect
+  local printProxy = common.printProxy
+  for i = 1, 3 do
+    printProxy{tostring(i), tostring(i+10)}:exact()
+  end
 end
 
 

--- a/tests/loadTests/LoopTests.lua
+++ b/tests/loadTests/LoopTests.lua
@@ -47,9 +47,12 @@ do
   --given
   local src = [=[
     t = {11,12,13,e="nope",f="don't"}
+    i = 0
     for a,b in ipairs( t ) do
       print(a,b)
+      i = i + 1
     end
+    return i
   ]=]
   local env = Env:new()
   local common = testUtils.common(env)
@@ -64,6 +67,7 @@ do
   for i = 1, 3 do
     printProxy{tostring(i), tostring(i+10)}:exact()
   end
+  test:var_eq(1, 3)
 end
 
 

--- a/tests/loadTests/MathModule.lua
+++ b/tests/loadTests/MathModule.lua
@@ -63,12 +63,7 @@ do
 
     local testSrc = src:gsub( "$1", info.func ):gsub("$2", table.concat(info.args,","))
 
-    local test = tester:add(info.func, env, function()
-      local scope = testUtils.newScope(Scope)
-      local results = testUtils.run(testSrc, scope, Loader, Async).varargs
-      if not results then error"Expected return value" end
-      return results[1].value
-    end)
+    local test = testUtils.codeTest(tester, info.func, env, libs, testSrc)
   
     test:var_eq(1, ("%.4f"):format(expected))
 
@@ -90,12 +85,7 @@ do
     return "%.4f":format( math.pi )
   ]=]
 
-  local test = tester:add("pi", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "pi", env, libs, src)
 
   test:var_eq(1, "3.1416")
 end
@@ -117,12 +107,7 @@ do
   math.randomseed(1234)
   local expected = ("%.4f, %.4f, %.4f"):format(math.random(), math.random(), math.random())
 
-  local test = tester:add("random and seed", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "random and seed", env, libs, src)
 
   test:var_eq(1, expected)
 end

--- a/tests/loadTests/OrderOfOps.lua
+++ b/tests/loadTests/OrderOfOps.lua
@@ -39,7 +39,7 @@ do
   local libs = testUtils.libs()
   local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
   
-  local setup = [=[
+  local template = [=[
     t = {}
     
     function t.add( x, y )
@@ -49,16 +49,13 @@ do
     t.inner = {
       value = 100
     }
+
+    return %s
   ]=]
   
   for expression, expected in pairs( tests ) do
-    local test = tester:add("Order: "..expression, env, function()
-      local scope = testUtils.newScope( Scope )
-      local fullExpression = "return "..expression
-      testUtils.run( setup, scope, Loader, Async )
-      local results = testUtils.run( fullExpression, scope, Loader, Async ).varargs
-      return results[1].value
-    end)
+    src = template:format( expression )
+    local test = testUtils.codeTest(tester, "Order: "..expression, env, libs, src)
 
     test:var_eq(1, expected, "Expression "..expression.." expected a value of "..tostring(expected)..", but got $1")
   end

--- a/tests/loadTests/ScopeTests.lua
+++ b/tests/loadTests/ScopeTests.lua
@@ -1,0 +1,60 @@
+local Tester = require"TestRunner"
+local Env = require"MockEnv"
+local testUtils = require"libs/testUtils"
+
+local matchers = require"MockProxy".static
+local eq = matchers.eq
+local any = matchers.any
+
+local tester = Tester:new()
+
+-----------------------------------------------------------------
+-- Tests
+-----------------------------------------------------------------
+
+--------------------
+-- function param --
+--------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local function paramTest( x )
+      x = x
+    end
+
+    paramTest( 10 )
+
+    return x, _G.x
+  ]=]
+
+  local test = testUtils.codeTest(tester, "function param", env, libs, src)
+
+  test:var_eq(1, nil)
+  test:var_eq(2, nil)
+end
+
+
+--------------------
+-- function param --
+--------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    table.serialize( _G )
+    return visited
+  ]=]
+
+  local test = testUtils.codeTest(tester, "table.serialize", env, libs, src)
+
+  test:var_eq(1, nil)
+end
+
+return tester

--- a/tests/loadTests/ScopeTests.lua
+++ b/tests/loadTests/ScopeTests.lua
@@ -37,6 +37,31 @@ do
   test:var_eq(2, nil)
 end
 
+---------------
+-- nil local --
+---------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local function paramTest( x )
+      x = x or 11
+    end
+
+    paramTest()
+
+    return x, _G.x
+  ]=]
+
+  local test = testUtils.codeTest(tester, "nil local", env, libs, src)
+
+  test:var_eq(1, nil)
+  test:var_eq(2, nil)
+end
+
 
 --------------------
 -- function param --

--- a/tests/loadTests/StringModule.lua
+++ b/tests/loadTests/StringModule.lua
@@ -26,12 +26,7 @@ do
     return str:sub(2,5)
   ]=]
 
-  local test = tester:add("sub", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "sub", env, libs, src)
 
   test:var_eq(1, "ello")
 end
@@ -50,12 +45,7 @@ do
     return str:find"ello"
   ]=]
 
-  local test = tester:add("find", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] or not results[2] then error"Expected return value" end
-    return results[1].value, results[2].value
-  end)
+  local test = testUtils.codeTest(tester, "find", env, libs, src)
 
   test:var_eq(1, 2)
   test:var_eq(2, 5)
@@ -75,12 +65,7 @@ do
     return #str:rep(10)
   ]=]
 
-  local test = tester:add("rep", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "rep", env, libs, src)
 
   test:var_eq(1, 10)
 end
@@ -99,12 +84,7 @@ do
     return str:match"e."
   ]=]
 
-  local test = tester:add("match", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "match", env, libs, src)
 
   test:var_eq(1, "el")
 end
@@ -128,12 +108,7 @@ do
     return i
   ]=]
 
-  local test = tester:add("gmatch", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "gmatch", env, libs, src)
 
   test:var_eq(1, 2)
 end
@@ -151,12 +126,7 @@ do
     return string.char( 97 )
   ]=]
 
-  local test = tester:add("char", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "char", env, libs, src)
 
   test:var_eq(1, "a")
 end
@@ -182,12 +152,7 @@ do
     return str:reverse()
   ]=]
 
-  local test = tester:add("reverse", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "reverse", env, libs, src)
 
   test:var_eq(1, "!dlrow olleH")
 end
@@ -206,12 +171,7 @@ do
     return str:upper()
   ]=]
 
-  local test = tester:add("upper", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "upper", env, libs, src)
 
   test:var_eq(1, "HELLO WORLD!")
 end
@@ -230,12 +190,7 @@ do
     return str:len()
   ]=]
 
-  local test = tester:add("len", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "len", env, libs, src)
 
   test:var_eq(1, 12)
 end
@@ -254,12 +209,7 @@ do
     return str:gsub("l","L")
   ]=]
 
-  local test = tester:add("gsub", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "gsub", env, libs, src)
 
   test:var_eq(1, "HeLLo worLd!")
 end
@@ -277,12 +227,7 @@ do
     return string.byte"a"
   ]=]
 
-  local test = tester:add("byte", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "byte", env, libs, src)
 
   test:var_eq(1, 97)
 end
@@ -301,12 +246,7 @@ do
     return str:format("Hello", "world")
   ]=]
 
-  local test = tester:add("format", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "format", env, libs, src)
 
   test:var_eq(1, "Hello world!")
 end
@@ -325,12 +265,7 @@ do
     return str:lower()
   ]=]
 
-  local test = tester:add("lower", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "lower", env, libs, src)
 
   test:var_eq(1, "hello world!")
 end

--- a/tests/loadTests/TableModule.lua
+++ b/tests/loadTests/TableModule.lua
@@ -27,12 +27,7 @@ do
     return t[1]
   ]=]
 
-  local test = tester:add("insert empty", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "insert empty", env, libs, src)
 
   test:var_eq(1, "first")
 end
@@ -52,12 +47,7 @@ do
     return t[1]
   ]=]
 
-  local test = tester:add("insert first", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "insert first", env, libs, src)
 
   test:var_eq(1, "first")
 end
@@ -77,12 +67,7 @@ do
     return t[2]
   ]=]
 
-  local test = tester:add("insert middle", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "insert middle", env, libs, src)
 
   test:var_eq(1, "middle")
 end
@@ -102,12 +87,7 @@ do
     return t[#t]
   ]=]
 
-  local test = tester:add("insert last", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "insert last", env, libs, src)
 
   test:var_eq(1, "last")
 end
@@ -127,12 +107,7 @@ do
     return v, t[1]
   ]=]
 
-  local test = tester:add("remove first", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] or not results[2] then error"Expected return value" end
-    return results[1].value, results[2].value
-  end)
+  local test = testUtils.codeTest(tester, "remove first", env, libs, src)
 
   test:var_eq(1, "first", "Expected return value \"first\" from `table.remove`, got $1")
   test:var_eq(2, "middle", "Expected first element removed, found $1")
@@ -153,12 +128,7 @@ do
     return v, t[2]
   ]=]
 
-  local test = tester:add("remove middle", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] or not results[2] then error"Expected return value" end
-    return results[1].value, results[2].value
-  end)
+  local test = testUtils.codeTest(tester, "remove middle", env, libs, src)
 
   test:var_eq(1, "middle", "Expected return value \"middle\" from `table.remove`, got $1")
   test:var_eq(2, "last", "Expected middle element removed, found $1")
@@ -179,12 +149,7 @@ do
     return v, #t
   ]=]
 
-  local test = tester:add("remove last", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] or not results[2] then error"Expected return value" end
-    return results[1].value, results[2].value
-  end)
+  local test = testUtils.codeTest(tester, "remove last", env, libs, src)
 
   test:var_eq(1, "last", "Expected return value \"last\" from `table.remove`, got $1")
   test:var_eq(2, 2, "Expected table length of 2, got $1")
@@ -204,12 +169,7 @@ do
     return #t, t[1], t.n
   ]=]
 
-  local test = tester:add("pack", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] or not results[2] or not results[3] then error"Expected return values" end
-    return results[1].value, results[2].value, results[3].value
-  end)
+  local test = testUtils.codeTest(tester, "pack", env, libs, src)
 
   test:var_eq(1, 3, "Expected table length of 3, got $1")
   test:var_eq(2, "first", "Expected table index 1 to contain \"first\", got $1")
@@ -230,12 +190,7 @@ do
     return table.concat(t)
   ]=]
 
-  local test = tester:add("concat", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "concat", env, libs, src)
 
   test:var_eq(1, "firstmiddlelast")
 end
@@ -254,12 +209,7 @@ do
     return table.concat(t, ",")
   ]=]
 
-  local test = tester:add("concat with joiner", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "concat with joiner", env, libs, src)
 
   test:var_eq(1, "first,middle,last")
 end
@@ -278,12 +228,7 @@ do
     return table.concat(t, ",", 2, 4)
   ]=]
 
-  local test = tester:add("concat with joiner and range", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    return results[1].value
-  end)
+  local test = testUtils.codeTest(tester, "concat with joiner and range", env, libs, src)
 
   test:var_eq(1, "first,middle,last")
 end
@@ -302,12 +247,7 @@ do
     return table.unpack(t)
   ]=]
 
-  local test = tester:add("unpack", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] or not results[2] or not results[3] then error"Expected return value" end
-    return results[1].value, results[2].value, results[3].value
-  end)
+  local test = testUtils.codeTest(tester, "unpack", env, libs, src)
 
   test:var_eq(1, "first",  "Expected unpack value 1 to be \"first\", got $1")
   test:var_eq(2, "middle", "Expected unpack value 2 to be \"middle\", got $1")
@@ -329,35 +269,23 @@ do
     table.sort(t, function( a, b )
       return a < b
     end)
-    return t
+    return table.unpack( t )
   ]=]
 
-  local test = tester:add("sort", env, function()
-    local scope = testUtils.newScope(Scope)
-    local results = testUtils.run(src, scope, Loader, Async).varargs
-    if not results[1] then error"Expected return value" end
-    local t = results[1].value
-    local indexer = Loader.tableIndexes[t]
-    if not indexer then error("no table index available") end
+  local test = testUtils.codeTest(tester, "sort", env, libs, src)
 
-    local n = 0
-    local sorted = true
-    local d = {}
-    for i=1, #indexer-1 do
-      local k1 = indexer[i]
-      local v1 = t[k1]
-      local k2 = indexer[i+1]
-      local v2 = t[k2]
-      table.insert(d, (v1.value .. " < " .. v2.value))
-      if v1.value > v2.value then
-        sorted = false
+  test:expect(function()
+    local a = test.actionResults[1]
+    for i = 2, 6 do
+      b = test.actionResults[i]
+      if a > b then
+        return false, "Not sorted: "..table.concat(d," | ")
       end
+      a = b
     end
-    if not sorted then error("Not sorted: "..table.concat(d," | ")) end
-    return #indexer == 6 and sorted
+    return true, ""
   end)
 
-  test:var_isTrue(1, "Table is not sorted")
 end
 
 --------------


### PR DESCRIPTION
test: use plasma scope and testUtils
str-> string + ipairs (types sometimes showed up as `str`
Scope bug where recursive functions referred to the same parent

Bug where function params are nil then a value is assigned to it in function, but it goes to global

fixes infinite loop if error occurs in xpcall handler function