### PR TITLE
fix: 1.0.2 repeat until loops, assert and table assignment

### DIFF
--- a/tests/loadTests/CoroutineModule.lua
+++ b/tests/loadTests/CoroutineModule.lua
@@ -199,4 +199,32 @@ do
   test:var_eq(1, "dead", "Expected finished thread to have status \"dead\", got $1")
 end
 
+------------------------
+-- can store in table --
+------------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+    local thread = coroutine.create(function() end)
+    numTbl = { thread }
+    hashTbl = { [thread] = true }
+    hashTbl2 = {}
+    hashTbl2[ thread ] = true
+
+    k = next(hashTbl)
+    return type(numTbl[1]), k == thread, type(k), type(next(hashTbl2))
+  ]=]
+
+  local test = testUtils.codeTest(tester, "can store in table", env, libs, src)
+
+  test:var_eq(1, "thread")
+  test:var_eq(2, true)
+  test:var_eq(3, "thread")
+  test:var_eq(4, "thread")
+end
+
 return tester

--- a/tests/loadTests/LoopTests.lua
+++ b/tests/loadTests/LoopTests.lua
@@ -120,5 +120,29 @@ do
   test:var_eq(1, 6)
 end
 
+------------------
+-- repeat until --
+------------------
+do
+  --given
+  local src = [=[
+    local i = 0
+    repeat
+      i = i+1
+    until i > 5
+    return i
+  ]=]
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  --test code
+  local test = testUtils.codeTest(tester, "repeat until", env, libs, src)
+
+  --expect
+  test:var_eq(1, 6)
+end
+
 
 return tester


### PR DESCRIPTION
 - fixes `t[ k ] = something` when `k` is a thread
 - assert error msg not thrown as table anymore making it readable
 - repeat until loops are working now