### PR TITLE
fix: missing stack value for function return

### DIFF
--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -1,4 +1,4 @@
-VERSION = "Meta Lua 1.0.2"
+VERSION = "Meta Lua 1.0.3"
 --Authors:
 --  TheIncgi
 -- Source: https://github.com/TheIncgi/Plasma-projects/blob/main/libs/Load.lua

--- a/libs/Load.lua
+++ b/libs/Load.lua
@@ -2312,7 +2312,7 @@ function Loader.eval( postfix, scope, line )
                     if result and result.varargs then
                       result.len = math.min(1, #result.varargs )
                     end
-                    table.insert( stack, result )
+                    table.insert( stack, result or Loader.constants["nil"] )
                   end)
                   return true
                 end

--- a/tests/loadTests/ShortCircuiting.lua
+++ b/tests/loadTests/ShortCircuiting.lua
@@ -34,6 +34,25 @@ do
   test:var_eq(1, true)
 end
 
+-------------------
+-- empty func or --
+-------------------
+do
+  local env = Env:new()
+  local common = testUtils.common(env)
+  local libs = testUtils.libs()
+  local Loader, Async, Net, Scope = libs.Loader, libs.Async, libs.Net, libs.Scope
+
+  local src = [=[
+  function test() end
+   return test() or 10
+  ]=]
+
+  local test = testUtils.codeTest(tester, "empty func or", env, libs, src)
+
+  test:var_eq(1, 10)
+end
+
 ---------
 -- and --
 ---------


### PR DESCRIPTION
example:
```lua
function test()
end
x = test() or something
```

evaluation now puts `nil` in if no value is returned